### PR TITLE
Adding erlang R18 build, and updating rebar and relx to last releases

### DIFF
--- a/18/Dockerfile
+++ b/18/Dockerfile
@@ -1,0 +1,47 @@
+FROM debian:jessie
+
+MAINTAINER Correl Roush <correl@gmail.com>
+
+ENV OTP_VERSION 18.1
+ENV REBAR_VERSION 2.6.1
+ENV RELX_VERSION v3.5.0
+
+RUN DEBIAN_FRONTEND=noninteractive  \
+    apt-get update -qq \
+    && apt-get install -y \
+       build-essential \
+       git \
+       libncurses5-dev \
+       openssl \
+       libssl-dev \
+       fop \
+       xsltproc \
+       unixodbc-dev
+
+ADD http://erlang.org/download/otp_src_${OTP_VERSION}.tar.gz /usr/src/
+RUN cd /usr/src \
+    && tar xf otp_src_${OTP_VERSION}.tar.gz \
+    && cd otp_src_${OTP_VERSION} \
+    && ./configure \
+    && make \
+    && make install \
+    && cd / && rm -rf /usr/src/otp_src_${OTP_VERSION}
+
+ADD https://github.com/rebar/rebar/archive/${REBAR_VERSION}.tar.gz  /usr/src/rebar-${REBAR_VERSION}.tar.gz
+RUN cd /usr/src \
+    && tar zxf rebar-${REBAR_VERSION}.tar.gz \
+    && cd rebar-${REBAR_VERSION} \
+    && make \
+    && cp rebar /usr/bin/rebar \
+    && cd / && rm -rf /usr/src/rebar-${REBAR_VERSION}
+
+ADD https://github.com/erlware/relx/archive/${RELX_VERSION}.tar.gz /usr/src/relx-${RELX_VERSION}.tar.gz
+RUN cd /usr/src \
+    && tar zxf relx-${RELX_VERSION}.tar.gz \
+    && cd relx-${RELX_VERSION#v} \
+    && ./rebar3 update \
+    && ./rebar3 escriptize \
+    && cp _build/default/bin/relx /usr/bin/relx \
+    && cd / && rm -rf /usr/src/relx-${RELX_VERSION#v}
+
+CMD ["erl"]


### PR DESCRIPTION
Hello @correl 

This PR adds last erlang r18 release; and also updates rebar and relx to last available versions
